### PR TITLE
Implement manual watering and schedule control for Moen devices

### DIFF
--- a/custom_components/moen_smart_water_network/__init__.py
+++ b/custom_components/moen_smart_water_network/__init__.py
@@ -111,6 +111,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
+    # Cancel MQTT subscription tasks for all devices before unloading
+    entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+    devices = entry_data.get("devices", [])
+    for device in devices:
+        await device.async_shutdown()
+
     if unloaded := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unloaded

--- a/custom_components/moen_smart_water_network/api.py
+++ b/custom_components/moen_smart_water_network/api.py
@@ -291,6 +291,25 @@ class ApiClient:
             method="post", url=f"{API_BASE_URL}/irrigation/manual", data=data
         )
 
+    async def async_cancel_manual_run(self, device_id: str) -> dict:
+        """Cancel a running manual run."""
+        return await self._request_with_refresh(
+            method="delete",
+            url=f"{API_BASE_URL}/irrigation/manual",
+            params={"duid": device_id},
+        )
+
+    async def async_update_schedule_status(
+        self, schedule_id: str, status: str
+    ) -> dict:
+        """Update a schedule's status (active/inactive)."""
+        data = {"status": status}
+        return await self._request_with_refresh(
+            method="patch",
+            url=f"{API_BASE_URL}/irrigation/schedules/{schedule_id}",
+            data=data,
+        )
+
     async def async_enable_zone(self, device_id: str, zone_id: str) -> dict:
         """Enable a zone."""
         data = {"enabled": True}

--- a/custom_components/moen_smart_water_network/api.py
+++ b/custom_components/moen_smart_water_network/api.py
@@ -403,7 +403,9 @@ class ApiClient:
                     )
 
                 response.raise_for_status()
-                return await response.json()
+                if response.content_type == "application/json":
+                    return await response.json()
+                return None
 
         except TimeoutError as exception:
             msg = f"Timeout error fetching information from {url}: {exception}"

--- a/custom_components/moen_smart_water_network/coordinator.py
+++ b/custom_components/moen_smart_water_network/coordinator.py
@@ -77,10 +77,11 @@ class MoenDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             client.async_subscribe(data["clientId"], callback=self._subscribe_update_cb)
         )
 
-    @callback
     def _subscribe_update_cb(self, msg: Any) -> None:
+        """Handle MQTT shadow messages (called from AWS IoT SDK thread)."""
         _LOGGER.debug("mqtt: received message of type %s: %s", type(msg).__name__, msg)
 
+        reported = None
         if hasattr(msg, "current"):
             if hasattr(msg.current.state, "desired"):
                 _LOGGER.debug(
@@ -92,9 +93,6 @@ class MoenDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 _LOGGER.debug(
                     "mqtt: current reported state: %s", msg.current.state.reported
                 )
-                merge(self._shadow_state, reported)
-
-                self.hass.add_job(self.async_update_listeners)
         if hasattr(msg, "state"):
             if hasattr(msg.state, "desired"):
                 _LOGGER.debug("mqtt: state.desired state: %s", msg.state.desired)
@@ -102,9 +100,17 @@ class MoenDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             if hasattr(msg.state, "reported") and msg.state.reported is not None:
                 reported = msg.state.reported
                 _LOGGER.debug("mqtt: state.reported state: %s", msg.state.reported)
-                merge(self._shadow_state, reported)
 
-                self.hass.add_job(self.async_update_listeners)
+        if reported is not None:
+            # Schedule the state merge on the event loop to avoid
+            # mutating _shadow_state from the MQTT SDK's IO thread.
+            self.hass.loop.call_soon_threadsafe(self._apply_shadow_update, reported)
+
+    @callback
+    def _apply_shadow_update(self, reported: dict) -> None:
+        """Merge reported shadow state and notify listeners (runs on event loop)."""
+        merge(self._shadow_state, reported)
+        self.async_update_listeners()
 
     async def _async_update_data(self) -> CoordinatorData:
         """Update data via library."""

--- a/custom_components/moen_smart_water_network/coordinator.py
+++ b/custom_components/moen_smart_water_network/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
@@ -101,6 +102,9 @@ class MoenDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             if hasattr(msg.state, "reported") and msg.state.reported is not None:
                 reported = msg.state.reported
                 _LOGGER.debug("mqtt: state.reported state: %s", msg.state.reported)
+                merge(self._shadow_state, reported)
+
+                self.hass.add_job(self.async_update_listeners)
 
     async def _async_update_data(self) -> CoordinatorData:
         """Update data via library."""
@@ -212,3 +216,13 @@ class MoenDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         return next(
             (zone for zone in self.zones() if zone["clientId"] == str(client_id)), None
         )
+
+    async def async_shutdown(self) -> None:
+        """Cancel the MQTT subscription task and clean up."""
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None

--- a/custom_components/moen_smart_water_network/switch.py
+++ b/custom_components/moen_smart_water_network/switch.py
@@ -130,14 +130,23 @@ class ZoneRunSwitch(MoenEntity, SwitchEntity):
         """Return true if the switch is on."""
         return str(self._device.hydra_overview.get("zoneID")) == str(self._zone_number)
 
-    async def async_turn_on(self, **_: Any) -> None:
-        """Turn on the switch."""
-        raise NotImplementedError
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the switch to start watering this zone."""
+        duration = kwargs.get("duration", 5)
+        zone_id = f"{self._device.id}_{self._zone_number}"
+        zones = [{"id": zone_id, "duration": duration}]
+        await self._device.client.async_manual_run(
+            device_id=self._device.id,
+            name="Home Assistant Manual Run",
+            zones=zones,
+        )
         await self._device.async_request_refresh()
 
     async def async_turn_off(self, **_: Any) -> None:
-        """Turn off the switch."""
-        raise NotImplementedError
+        """Turn off the switch to stop watering."""
+        await self._device.client.async_cancel_manual_run(
+            device_id=self._device.id,
+        )
         await self._device.async_request_refresh()
 
 
@@ -182,11 +191,15 @@ class ScheduleEnableSwitch(MoenEntity, SwitchEntity):
         )
 
     async def async_turn_on(self, **_: Any) -> None:
-        """Turn on the switch."""
-        raise NotImplementedError
+        """Turn on the switch to activate the schedule."""
+        await self._device.client.async_update_schedule_status(
+            schedule_id=self._id, status="active"
+        )
         await self._device.async_request_refresh()
 
     async def async_turn_off(self, **_: Any) -> None:
-        """Turn off the switch."""
-        raise NotImplementedError
+        """Turn off the switch to deactivate the schedule."""
+        await self._device.client.async_update_schedule_status(
+            schedule_id=self._id, status="inactive"
+        )
         await self._device.async_request_refresh()


### PR DESCRIPTION
## Summary
This PR implements functional control for manual watering zones and irrigation schedules in the Moen Smart Water Network integration. Previously, the switch controls raised `NotImplementedError`. The changes also include thread-safety improvements for MQTT message handling and proper cleanup on integration unload.

## Key Changes

### Switch Control Implementation
- **Manual Zone Watering**: Implemented `async_turn_on()` and `async_turn_off()` for zone switches to start/stop manual watering with configurable duration (default 5 minutes)
- **Schedule Control**: Implemented `async_turn_on()` and `async_turn_off()` for schedule switches to activate/deactivate irrigation schedules
- Updated docstrings to be more descriptive of actual functionality

### API Enhancements
- Added `async_cancel_manual_run()` method to stop active manual watering
- Added `async_update_schedule_status()` method to activate/deactivate schedules
- Fixed response handling to gracefully handle non-JSON responses (returns `None` instead of failing)

### Thread-Safety Improvements
- Fixed MQTT message handling in `coordinator.py` to avoid mutating state from the AWS IoT SDK's IO thread
- Introduced `_apply_shadow_update()` callback that runs on the event loop using `call_soon_threadsafe()`
- Removed `@callback` decorator from `_subscribe_update_cb()` since it performs thread-unsafe operations
- Added proper docstring explaining the threading model

### Integration Cleanup
- Implemented `async_shutdown()` method in coordinator to properly cancel MQTT subscription tasks
- Added cleanup logic in `async_unload_entry()` to call `async_shutdown()` on all devices before unloading platforms

## Notable Implementation Details
- Manual watering duration is passed via kwargs with a sensible default of 5 minutes
- Zone IDs are constructed as `{device_id}_{zone_number}` for the API calls
- Manual runs are identified with "Home Assistant Manual Run" for tracking purposes
- Thread-safe state updates use `hass.loop.call_soon_threadsafe()` to schedule operations on the event loop

https://claude.ai/code/session_01WhzhiJetiHfZ6Un8r2HqQc