### PR TITLE
fix: keep coordinator online when presence heartbeat fails

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -18,6 +18,23 @@ ignore = [
     "TRY003",
 ]
 
+[lint.per-file-ignores]
+# Tests favor readability over the strict "ALL" rule set used for the
+# integration code (mirrors the home-assistant/core test config).
+"tests/**/*" = [
+    "ANN001",  # missing type annotation for function argument (fixtures)
+    "ANN201",  # missing return type annotation
+    "ARG001",  # unused function argument (pytest fixtures)
+    "D103",    # missing docstring in public function
+    "D400",    # first line should end with a period
+    "D415",    # first line should end with punctuation
+    "E501",    # line too long
+    "ERA001",  # commented-out code (reference scaffolding)
+    "PLR2004", # magic value used in comparison
+    "S101",    # use of assert
+    "SLF001",  # private member accessed
+]
+
 [lint.flake8-pytest-style]
 fixture-parentheses = false
 

--- a/custom_components/moen_smart_water_network/coordinator.py
+++ b/custom_components/moen_smart_water_network/coordinator.py
@@ -162,11 +162,19 @@ class MoenDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
     async def _async_update_data(self) -> CoordinatorData:
         """Update data via library."""
+        LOGGER.debug("Updating data for %s", self._device_id)
+
+        # The presence "heartbeat" is a best-effort ping to tell Moen we are
+        # online. Moen's API has been returning 400/401 for it, and because it
+        # was the first call in the refresh, its failure aborted the whole
+        # update and marked every entity unavailable. Treat it as non-fatal so
+        # device/schedule data (and the MQTT shadow) keep flowing regardless.
         try:
-            LOGGER.debug("Updating data for %s", self._device_id)
-
             await self.client.async_user_presence()
+        except MoenApiError as exception:
+            LOGGER.debug("User presence update failed (ignored): %s", exception)
 
+        try:
             self._device_information = await self.client.async_get_device(
                 self._device_id
             )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,13 @@
+-r requirements.txt
+black
+flake8
+mypy==1.1.1
+pre-commit
+pytest
+pytest-homeassistant-custom-component
+pylint-pytest
+pylint
+pytest-aiohttp
+pytest-asyncio
+types-python-dateutil
+types-pytz

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the moen smart water network integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,187 @@
+"""Define fixtures available for all tests."""
+import pytest
+from homeassistant.const import CONF_ACCESS_TOKEN
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+)
+from pytest_homeassistant_custom_component.test_util.aiohttp import (
+    AiohttpClientMockResponse,
+)
+
+from custom_components.moen_smart_water_network.const import CONF_REFRESH_TOKEN, DOMAIN
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+# This fixture enables loading custom integrations in all tests.
+# Remove to enable selective use of this fixture
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    return
+
+
+@pytest.fixture
+def config_entry(hass):
+    """Config entry version 1 fixture."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_ACCESS_TOKEN: "TEST_USER_ID", CONF_REFRESH_TOKEN: ""},
+        version=1,
+    )
+
+
+# This fixture, when used, will result in calls to async_get_data to return None. To have the call
+# return a value, we would add the `return_value=<VALUE_TO_RETURN>` parameter to the patch call.
+# @pytest.fixture(name="bypass_get_data")
+# def bypass_get_data_fixture():
+#     """Skip calls to get data from API."""
+#     with patch("pyschlage.Schlage.locks"), patch("pyschlage.Schlage.users"):
+#         yield
+
+
+def mock_response(data: str) -> AiohttpClientMockResponse:
+    """Create a fake AiohttpClientMockResponse."""
+    return AiohttpClientMockResponse(
+        "GET", "https://api.prod.iot.moen.com/v3/devices", response=(data)
+    )
+
+
+@pytest.fixture(name="api_responses")
+def mock_api_responses() -> list[str]:
+    """
+    Fixture to set up a list of fake API responsees for tests to extend.
+
+    These are returned in the order they are requested by the update coordinator.
+    """
+    return []
+
+
+@pytest.fixture(name="responses")
+def mock_responses(api_responses: list[str]) -> list[AiohttpClientMockResponse]:
+    """Fixture to set up a list of fake API responsees for tests to extend."""
+    return [mock_response(api_response) for api_response in api_responses]
+
+
+# @pytest.fixture
+# def aioclient_mock_fixture(aioclient_mock):
+#     """Fixture to provide a aioclient mocker."""
+#     now = round(time.time())
+#     # Mocks the login response for flo.
+#     aioclient_mock.post(
+#         "https://api.meetflo.com/api/v1/users/auth",
+#         text=json.dumps(
+#             {
+#                 "token": TEST_TOKEN,
+#                 "tokenPayload": {
+#                     "user": {"user_id": TEST_USER_ID, "email": TEST_EMAIL_ADDRESS},
+#                     "timestamp": now,
+#                 },
+#                 "tokenExpiration": 86400,
+#                 "timeNow": now,
+#             }
+#         ),
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         status=HTTPStatus.OK,
+#     )
+#     # Mocks the presence ping response for flo.
+#     aioclient_mock.post(
+#         "https://api-gw.meetflo.com/api/v2/presence/me",
+#         text=load_fixture("flo/ping_response.json"),
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         status=HTTPStatus.OK,
+#     )
+#     # Mocks the devices for flo.
+#     aioclient_mock.get(
+#         "https://api-gw.meetflo.com/api/v2/devices/98765",
+#         text=load_fixture("flo/device_info_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#     )
+#     aioclient_mock.get(
+#         "https://api-gw.meetflo.com/api/v2/devices/32839",
+#         text=load_fixture("flo/device_info_response_detector.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#     )
+#     # Mocks the water consumption for flo.
+#     aioclient_mock.get(
+#         "https://api-gw.meetflo.com/api/v2/water/consumption",
+#         text=load_fixture("flo/water_consumption_info_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#     )
+#     # Mocks the location info for flo.
+#     aioclient_mock.get(
+#         "https://api-gw.meetflo.com/api/v2/locations/mmnnoopp",
+#         text=load_fixture("flo/location_info_expand_devices_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#     )
+#     # Mocks the user info for flo.
+#     aioclient_mock.get(
+#         "https://api-gw.meetflo.com/api/v2/users/12345abcde",
+#         text=load_fixture("flo/user_info_expand_locations_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         params={"expand": "locations"},
+#     )
+#     # Mocks the user info for flo.
+#     aioclient_mock.get(
+#         "https://api-gw.meetflo.com/api/v2/users/12345abcde",
+#         text=load_fixture("flo/user_info_expand_locations_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#     )
+#     # Mocks the valve open call for flo.
+#     aioclient_mock.post(
+#         "https://api-gw.meetflo.com/api/v2/devices/98765",
+#         text=load_fixture("flo/device_info_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         json={"valve": {"target": "open"}},
+#     )
+#     # Mocks the valve close call for flo.
+#     aioclient_mock.post(
+#         "https://api-gw.meetflo.com/api/v2/devices/98765",
+#         text=load_fixture("flo/device_info_response_closed.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         json={"valve": {"target": "closed"}},
+#     )
+#     # Mocks the health test call for flo.
+#     aioclient_mock.post(
+#         "https://api-gw.meetflo.com/api/v2/devices/98765/healthTest/run",
+#         text=load_fixture("flo/user_info_expand_locations_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#     )
+#     # Mocks the health test call for flo.
+#     aioclient_mock.post(
+#         "https://api-gw.meetflo.com/api/v2/locations/mmnnoopp/systemMode",
+#         text=load_fixture("flo/user_info_expand_locations_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         json={"systemMode": {"target": "home"}},
+#     )
+#     # Mocks the health test call for flo.
+#     aioclient_mock.post(
+#         "https://api-gw.meetflo.com/api/v2/locations/mmnnoopp/systemMode",
+#         text=load_fixture("flo/user_info_expand_locations_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         json={"systemMode": {"target": "away"}},
+#     )
+#     # Mocks the health test call for flo.
+#     aioclient_mock.post(
+#         "https://api-gw.meetflo.com/api/v2/locations/mmnnoopp/systemMode",
+#         text=load_fixture("flo/user_info_expand_locations_response.json"),
+#         status=HTTPStatus.OK,
+#         headers={"Content-Type": CONTENT_TYPE_JSON},
+#         json={
+#             "systemMode": {
+#                 "target": "sleep",
+#                 "revertMinutes": 120,
+#                 "revertMode": "home",
+#             }
+#         },
+#     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Define fixtures available for all tests."""
+
 import pytest
 from homeassistant.const import CONF_ACCESS_TOKEN
 from pytest_homeassistant_custom_component.common import (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,94 @@
+"""Tests for the MoenDataUpdateCoordinator update flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.moen_smart_water_network.coordinator import (
+    MoenDataUpdateCoordinator,
+)
+from custom_components.moen_smart_water_network.moen_api import (
+    MoenApiAuthenticationError,
+    MoenApiCommunicationError,
+)
+
+DEVICE_ID = "dev-1"
+DEVICE_DATA = {"duid": DEVICE_ID, "clientId": "client-1"}
+SCHEDULES = {"items": [{"id": "sched-1"}, {"id": "sched-2"}]}
+
+
+def _build_coordinator(hass: HomeAssistant, config_entry) -> MoenDataUpdateCoordinator:
+    """Build a coordinator with a mocked client and mqtt client."""
+    client = MagicMock()
+    client.async_user_presence = AsyncMock(return_value={})
+    client.async_get_device = AsyncMock(return_value=DEVICE_DATA)
+    client.async_get_schedules = AsyncMock(return_value=SCHEDULES)
+
+    return MoenDataUpdateCoordinator(
+        hass=hass,
+        client=client,
+        mqtt_client=MagicMock(),
+        device_id=DEVICE_ID,
+        data=DEVICE_DATA,
+        legacy_id="123",
+        config_entry=config_entry,
+    )
+
+
+async def test_presence_communication_failure_is_non_fatal(
+    hass: HomeAssistant, config_entry
+) -> None:
+    """A 400 on the presence heartbeat must not fail the whole update."""
+    coordinator = _build_coordinator(hass, config_entry)
+    coordinator.client.async_user_presence.side_effect = MoenApiCommunicationError(
+        "400, message='Bad Request'"
+    )
+
+    data = await coordinator._async_update_data()
+
+    assert data["device"] == DEVICE_DATA
+    assert set(data["schedules"]) == {"sched-1", "sched-2"}
+    coordinator.client.async_get_device.assert_awaited_once_with(DEVICE_ID)
+
+
+async def test_presence_auth_failure_is_non_fatal(
+    hass: HomeAssistant, config_entry
+) -> None:
+    """A 401/403 on the presence heartbeat must not trigger reauth on its own."""
+    coordinator = _build_coordinator(hass, config_entry)
+    coordinator.client.async_user_presence.side_effect = MoenApiAuthenticationError(
+        "Invalid credentials"
+    )
+
+    data = await coordinator._async_update_data()
+
+    assert data["device"] == DEVICE_DATA
+
+
+async def test_device_auth_failure_still_raises_reauth(
+    hass: HomeAssistant, config_entry
+) -> None:
+    """A genuine auth failure fetching device data still triggers reauth."""
+    coordinator = _build_coordinator(hass, config_entry)
+    coordinator.client.async_get_device.side_effect = MoenApiAuthenticationError(
+        "Invalid credentials"
+    )
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_device_communication_failure_still_raises_update_failed(
+    hass: HomeAssistant, config_entry
+) -> None:
+    """A communication failure fetching device data still fails the update."""
+    coordinator = _build_coordinator(hass, config_entry)
+    coordinator.client.async_get_device.side_effect = MoenApiCommunicationError(
+        "boom"
+    )
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -86,9 +86,7 @@ async def test_device_communication_failure_still_raises_update_failed(
 ) -> None:
     """A communication failure fetching device data still fails the update."""
     coordinator = _build_coordinator(hass, config_entry)
-    coordinator.client.async_get_device.side_effect = MoenApiCommunicationError(
-        "boom"
-    )
+    coordinator.client.async_get_device.side_effect = MoenApiCommunicationError("boom")
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()


### PR DESCRIPTION
## Summary
The coordinator's 15s refresh called `async_user_presence()` first, before fetching device + schedule data. Moen's API started returning 400 (and intermittently 401) for `POST /v1/user/me/presence`, which raised `UpdateFailed`/`ConfigEntryAuthFailed` and aborted the whole update — marking every entity (zone valves, sensors, numbers, calendar) unavailable even though device data and the MQTT shadow were healthy.

## Key Changes
- Treat the presence ping as best-effort: swallow `MoenApiError` from it and keep polling.
- Genuine auth/comms failures on the device + schedule fetches still raise `ConfigEntryAuthFailed` / `UpdateFailed`.
- Add `tests/test_coordinator.py` covering presence 400/401 (non-fatal), device-fetch auth → reauth, and device-fetch comms → UpdateFailed, plus the test infra needed to run it.