### PR TITLE
feat: add username/password login option to config flow

### DIFF
--- a/custom_components/moen_smart_water_network/__init__.py
+++ b/custom_components/moen_smart_water_network/__init__.py
@@ -12,7 +12,12 @@ import logging
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
-from homeassistant.const import CONF_ACCESS_TOKEN, Platform
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    Platform,
+)
 from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
@@ -95,9 +100,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = {}
     try:
         auth = MoenAuth(
-            access_token=entry.data[CONF_ACCESS_TOKEN],
-            refresh_token=entry.data[CONF_REFRESH_TOKEN],
             session=session,
+            access_token=entry.data.get(CONF_ACCESS_TOKEN),
+            refresh_token=entry.data.get(CONF_REFRESH_TOKEN),
+            username=entry.data.get(CONF_USERNAME),
+            password=entry.data.get(CONF_PASSWORD),
         )
         client = MoenApiClient(auth=auth, session=session)
         mqtt_client = MoenMqttClient(auth=auth)

--- a/custom_components/moen_smart_water_network/config_flow.py
+++ b/custom_components/moen_smart_water_network/config_flow.py
@@ -2,12 +2,42 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_REFRESH_TOKEN, DOMAIN
+from .moen_api import (
+    MoenApiAuthenticationError,
+    MoenApiCommunicationError,
+    MoenAuth,
+)
+
+TITLE = "Moen Smart Water Network"
+
+CREDENTIALS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): selector.TextSelector(),
+        vol.Required(CONF_PASSWORD): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
+        ),
+    }
+)
+
+TOKEN_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ACCESS_TOKEN): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
+        ),
+        vol.Required(CONF_REFRESH_TOKEN): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
+        ),
+    }
+)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -17,32 +47,60 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self,
-        user_input: dict | None = None,
+        user_input: dict[str, Any] | None = None,  # noqa: ARG002
     ) -> config_entries.ConfigFlowResult:
-        """Handle a flow initialized by the user."""
-        _errors = {}
+        """Let the user choose an authentication method."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["credentials", "token"],
+        )
+
+    async def async_step_credentials(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Authenticate with a Moen account username and password."""
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            return self.async_create_entry(
-                title="Moen Smart Water Network",
-                data=user_input,
+            auth = MoenAuth(
+                session=async_get_clientsession(self.hass),
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
             )
+            try:
+                await auth.async_login()
+            except MoenApiAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except MoenApiCommunicationError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=TITLE,
+                    data={
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_ACCESS_TOKEN: auth.access_token,
+                        CONF_REFRESH_TOKEN: auth.refresh_token,
+                    },
+                )
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_ACCESS_TOKEN): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.PASSWORD
-                        ),
-                    ),
-                    vol.Required(CONF_REFRESH_TOKEN): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.PASSWORD
-                        ),
-                    ),
-                }
-            ),
-            errors=_errors,
+            step_id="credentials",
+            data_schema=CREDENTIALS_SCHEMA,
+            errors=errors,
         )
+
+    async def async_step_token(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Configure using manually-extracted OAuth tokens."""
+        if user_input is not None:
+            return self.async_create_entry(title=TITLE, data=user_input)
+
+        return self.async_show_form(step_id="token", data_schema=TOKEN_SCHEMA)

--- a/custom_components/moen_smart_water_network/moen_api/auth.py
+++ b/custom_components/moen_smart_water_network/moen_api/auth.py
@@ -17,6 +17,7 @@ from .const import COGNITO_ENDPOINT, OAUTH_CLIENT_ID, OAUTH_URL, USER_AGENT
 from .exceptions import (
     MoenApiAuthenticationError,
     MoenApiCommunicationError,
+    MoenApiError,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,29 +28,80 @@ class MoenAuth:
 
     def __init__(
         self,
-        access_token: str,
-        refresh_token: str,
         session: ClientSession,
+        access_token: str | None = None,
+        refresh_token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
     ) -> None:
-        """Initialize with OAuth2 tokens."""
+        """
+        Initialize with OAuth2 tokens and/or account credentials.
+
+        Either pre-obtained ``access_token``/``refresh_token`` or account
+        ``username``/``password`` (or both) may be supplied. When credentials
+        are present they allow a full re-login if the refresh token expires.
+        """
         self._session = session
         self._token = access_token
         self._refresh_token = refresh_token
+        self._username = username
+        self._password = password
         self._token_expiration: datetime.datetime | None = None
         self._id_token: str | None = None
 
     @property
-    def access_token(self) -> str:
+    def access_token(self) -> str | None:
         """Return the current access token."""
         return self._token
+
+    @property
+    def refresh_token(self) -> str | None:
+        """Return the current refresh token."""
+        return self._refresh_token
 
     @property
     def id_token(self) -> str | None:
         """Return the current ID token."""
         return self._id_token
 
+    def _apply_token_response(self, auth_response: dict) -> None:
+        """Store tokens from an OAuth2 token response."""
+        token = auth_response["token"]
+        self._token = token["access_token"]
+        self._refresh_token = token.get("refresh_token", self._refresh_token)
+        self._id_token = token.get("id_token", self._id_token)
+        expires_in = token.get("expires_in", 3600)
+        self._token_expiration = datetime.datetime.now(
+            tz=datetime.UTC
+        ) + datetime.timedelta(seconds=expires_in)
+        _LOGGER.debug(
+            "Received new access token that expires in %s at %s",
+            expires_in,
+            self._token_expiration,
+        )
+
+    async def async_login(self) -> None:
+        """Obtain new tokens using the account username and password."""
+        if not self._username or not self._password:
+            msg = "No account credentials available for login"
+            raise MoenApiAuthenticationError(msg)
+        _LOGGER.debug("Logging in with account credentials")
+        auth_response: dict = await self._api_wrapper(
+            method="post",
+            url=OAUTH_URL,
+            data={
+                "client_id": OAUTH_CLIENT_ID,
+                "username": self._username,
+                "password": self._password,
+            },
+        )
+        self._apply_token_response(auth_response)
+
     async def async_refresh_token(self) -> None:
         """Refresh tokens from the OAuth2 endpoint."""
+        if not self._refresh_token:
+            msg = "No refresh token available"
+            raise MoenApiAuthenticationError(msg)
         _LOGGER.debug("Requesting new access token")
         auth_response: dict = await self._api_wrapper(
             method="post",
@@ -60,25 +112,26 @@ class MoenAuth:
                 "grant_type": "refresh_token",
             },
         )
+        self._apply_token_response(auth_response)
 
-        self._token = auth_response["token"]["access_token"]
-        self._token_expiration = datetime.datetime.now(
-            tz=datetime.UTC
-        ) + datetime.timedelta(seconds=auth_response["token"]["expires_in"])
-        self._id_token = auth_response["token"]["id_token"]
-
-        _LOGGER.debug(
-            "Received new access token that expires in %s at %s",
-            auth_response["token"]["expires_in"],
-            self._token_expiration,
-        )
+    async def async_reauthenticate(self) -> None:
+        """Refresh the access token, falling back to a full login if needed."""
+        try:
+            await self.async_refresh_token()
+        except MoenApiError:
+            if not (self._username and self._password):
+                raise
+            _LOGGER.info(
+                "Token refresh failed; re-authenticating with account credentials"
+            )
+            await self.async_login()
 
     async def async_ensure_token(self) -> None:
         """Refresh the token if it is expired or about to expire."""
         if self._token_expiration is None or datetime.datetime.now(
             tz=datetime.UTC
         ) >= self._token_expiration - datetime.timedelta(minutes=5):
-            await self.async_refresh_token()
+            await self.async_reauthenticate()
 
     def get_auth_headers(self) -> dict[str, str]:
         """Return Authorization headers using the current access token."""

--- a/custom_components/moen_smart_water_network/moen_api/client.py
+++ b/custom_components/moen_smart_water_network/moen_api/client.py
@@ -138,17 +138,17 @@ class MoenApiClient:
         params: dict | None = None,
         data: dict | None = None,
     ) -> Any:
-        """Make a request, refreshing auth tokens on 401/403."""
-        refreshed = False
+        """Make a request, re-authenticating on 401/403."""
+        reauthed = False
         for _ in range(2):
             try:
                 return await self._api_wrapper(
                     method=method, url=url, data=data, params=params
                 )
             except MoenApiAuthenticationError:
-                if not refreshed:
-                    await self._auth.async_refresh_token()
-                    refreshed = True
+                if not reauthed:
+                    await self._auth.async_reauthenticate()
+                    reauthed = True
                     continue
                 raise
         return None  # unreachable, satisfies type checker

--- a/custom_components/moen_smart_water_network/strings.json
+++ b/custom_components/moen_smart_water_network/strings.json
@@ -3,7 +3,23 @@
     "step": {
       "user": {
         "title": "Moen Smart Water Network",
-        "description": "Configure your Moen Smart Water Network integration",
+        "description": "Choose how to connect to your Moen Smart Water Network account.",
+        "menu_options": {
+          "credentials": "Username and password",
+          "token": "Access and refresh tokens (advanced)"
+        }
+      },
+      "credentials": {
+        "title": "Moen account",
+        "description": "Enter your Moen Smart Water Network account email and password. If you sign in with Apple or Google, use the token option instead.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      },
+      "token": {
+        "title": "OAuth tokens",
+        "description": "Paste the access and refresh tokens captured from the Moen app.",
         "data": {
           "access_token": "Access Token",
           "refresh_token": "Refresh Token"
@@ -14,6 +30,9 @@
       "cannot_connect": "Failed to connect to Moen API",
       "invalid_auth": "Invalid authentication credentials",
       "unknown": "Unexpected error occurred"
+    },
+    "abort": {
+      "already_configured": "This Moen account is already configured"
     }
   },
   "entity": {

--- a/custom_components/moen_smart_water_network/translations/en.json
+++ b/custom_components/moen_smart_water_network/translations/en.json
@@ -1,18 +1,123 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "description": "If you need help with the configuration have a look here: https://github.com/ludeeus/integration_blueprint",
-                "data": {
-                    "username": "Username",
-                    "password": "Password"
-                }
-            }
-        },
-        "error": {
-            "auth": "Username/Password is wrong.",
-            "connection": "Unable to connect to the server.",
-            "unknown": "Unknown error occurred."
+  "config": {
+    "step": {
+      "user": {
+        "title": "Moen Smart Water Network",
+        "description": "Choose how to connect to your Moen Smart Water Network account.",
+        "menu_options": {
+          "credentials": "Username and password",
+          "token": "Access and refresh tokens (advanced)"
         }
+      },
+      "credentials": {
+        "title": "Moen account",
+        "description": "Enter your Moen Smart Water Network account email and password. If you sign in with Apple or Google, use the token option instead.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      },
+      "token": {
+        "title": "OAuth tokens",
+        "description": "Paste the access and refresh tokens captured from the Moen app.",
+        "data": {
+          "access_token": "Access Token",
+          "refresh_token": "Refresh Token"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to Moen API",
+      "invalid_auth": "Invalid authentication credentials",
+      "unknown": "Unexpected error occurred"
+    },
+    "abort": {
+      "already_configured": "This Moen account is already configured"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "connected": {
+        "name": "Connected"
+      },
+      "watering": {
+        "name": "Watering"
+      },
+      "rain_sensor": {
+        "name": "Rain Sensor"
+      },
+      "master_valve": {
+        "name": "Master Valve"
+      },
+      "flow_sensor": {
+        "name": "Flow Sensor"
+      },
+      "schedule_active": {
+        "name": "Schedule Active"
+      }
+    },
+    "sensor": {
+      "state": {
+        "name": "State"
+      },
+      "running_zone": {
+        "name": "Running Zone"
+      },
+      "rssi": {
+        "name": "RSSI"
+      },
+      "next_schedule_run": {
+        "name": "Next Schedule Run"
+      },
+      "run_remaining": {
+        "name": "Run Remaining"
+      },
+      "watering_mode": {
+        "name": "Watering Mode"
+      }
+    },
+    "switch": {
+      "zone_enabled": {
+        "name": "Zone Enabled"
+      },
+      "zone_run": {
+        "name": "Zone Run"
+      }
+    },
+    "valve": {
+      "zone_valve": {
+        "name": "Zone Valve"
+      }
+    },
+    "number": {
+      "zone_run_duration": {
+        "name": "Run Duration"
+      }
+    },
+    "calendar": {
+      "irrigation_calendar": {
+        "name": "Irrigation Calendar"
+      }
+    }
+  },
+  "services": {
+    "start_watering": {
+      "name": "Start watering",
+      "description": "Start manual watering for a specific zone on a Moen irrigation controller.",
+      "fields": {
+        "device_id": {
+          "name": "Device ID",
+          "description": "The device identifier (duid) for the Moen irrigation controller."
+        },
+        "zone_id": {
+          "name": "Zone ID",
+          "description": "The zone identifier to start watering."
+        },
+        "duration": {
+          "name": "Duration",
+          "description": "Duration to run watering in minutes."
+        }
+      }
+    }
+  }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,105 @@
+"""Test the Moen Smart Water Network config flow."""
+
+from unittest.mock import patch
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
+
+from custom_components.moen_smart_water_network.const import CONF_REFRESH_TOKEN, DOMAIN
+from custom_components.moen_smart_water_network.moen_api.const import OAUTH_URL
+
+TOKEN_RESPONSE = {
+    "token": {
+        "access_token": "AT",
+        "refresh_token": "RT",
+        "id_token": "IT",
+        "expires_in": 3600,
+    }
+}
+
+
+async def _start_menu(hass: HomeAssistant) -> dict:
+    """Start the flow and return the menu result."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+    return result
+
+
+async def test_credentials_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """A valid username/password logs in and stores the resulting tokens."""
+    aioclient_mock.post(OAUTH_URL, json=TOKEN_RESPONSE)
+
+    result = await _start_menu(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "credentials"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+
+    with patch(
+        "custom_components.moen_smart_water_network.async_setup_entry",
+        return_value=True,
+    ) as mock_setup:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "user@example.com", CONF_PASSWORD: "secret"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_USERNAME: "user@example.com",
+        CONF_PASSWORD: "secret",
+        CONF_ACCESS_TOKEN: "AT",
+        CONF_REFRESH_TOKEN: "RT",
+    }
+    assert len(mock_setup.mock_calls) == 1
+
+
+async def test_credentials_invalid_auth(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Bad credentials surface an invalid_auth error on the form."""
+    aioclient_mock.post(OAUTH_URL, status=401)
+
+    result = await _start_menu(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "credentials"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "user@example.com", CONF_PASSWORD: "wrong"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_token_flow(hass: HomeAssistant) -> None:
+    """The advanced token path stores the pasted tokens directly."""
+    result = await _start_menu(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "token"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "token"
+
+    with patch(
+        "custom_components.moen_smart_water_network.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_ACCESS_TOKEN: "a", CONF_REFRESH_TOKEN: "b"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_ACCESS_TOKEN: "a", CONF_REFRESH_TOKEN: "b"}


### PR DESCRIPTION
## Summary
Adds an optional Moen account username/password login alongside the existing token-paste setup. New users with a native Moen email/password account can now configure the integration without manually extracting tokens.

## Key Changes
- Config flow shows a menu: **username/password** (logs in via the OAuth2 endpoint, stores the resulting tokens) or **access/refresh tokens** (advanced, unchanged).
- `MoenAuth` accepts credentials and gains `async_login()` + `async_reauthenticate()` (refresh, falling back to a full re-login when credentials are stored); the client's 401/403 retry path routes through it, so credential users recover automatically when the refresh token expires.
- Rebuilds `translations/en.json` (was a stale integration-blueprint placeholder) and adds config-flow tests.

Note: Apple/Google-federated accounts have no password, so they still use the token path — the credentials form says so.